### PR TITLE
Combat Log mods for High Isle

### DIFF
--- a/core/events.lua
+++ b/core/events.lua
@@ -24,7 +24,7 @@
 
 		-- Target Events
 		EVENT_MANAGER:RegisterForEvent( "FTC" , EVENT_RETICLE_TARGET_CHANGED		, FTC.OnTargetChanged )
-			
+				
 		-- Attribute Events
 		EVENT_MANAGER:RegisterForEvent( "FTC" , EVENT_POWER_UPDATE					, FTC.OnPowerUpdate )
 		EVENT_MANAGER:RegisterForEvent( "FTC" , EVENT_UNIT_ATTRIBUTE_VISUAL_ADDED	, FTC.OnVisualAdded ) 
@@ -86,6 +86,21 @@
 	 ]]--
 	function FTC.OnLayerChange( eventCode, layerIndex, activeLayerIndex )
 		FTC:ToggleVisibility( activeLayerIndex )
+		
+		-- Mod High Isle non-alternating combat log 29-08-22
+		-- Quick get out if not enabled or alternating with chat
+		if ( not FTC.Vars.EnableLog ) then return end
+		if FTC.Vars.AlternateChat then 
+		    return 
+		else		
+			-- If not alternating combat log with chat then toggle
+			if (activeLayerIndex > 2) then
+				FTC.Log:ToggleLayer(true) 
+			else
+				FTC.Log:ToggleLayer(false) 
+			end
+		end
+		-- End mod
 	end
 
 	--[[ 

--- a/log/functions.lua
+++ b/log/functions.lua
@@ -62,11 +62,24 @@
 				end
 			end, 200)
 
-			ZO_PreHook(chatSystem, "Minimize", function() FTC.Log:SetupChat( false ) end)
-			ZO_PreHook(chatSystem, "Maximize", function() FTC.Log:SetupChat( true ) end)
+			-- Mod High Isle non-alternating combat log 29-08-22
+			-- Only hook to chat if alternating with chat
+			if FTC.Vars.AlternateChat then
+				ZO_PreHook(chatSystem, "Minimize", function() FTC.Log:SetupChat( false ) end)
+				ZO_PreHook(chatSystem, "Maximize", function() FTC.Log:SetupChat( true ) end)
+			end
+			--End mod
 			
 			isPreHooked = true
 		end)
+		
+		-- Mod High Isle non-alternating combat log 29-08-22
+		-- If not alternating with chat then enable
+        if (not FTC.Vars.AlternateChat) then FTC_CombatLog:SetHidden(false) end
+		
+		-- Indicate toggle to display (irrelevant when alternating with chat)
+		FTC.init.toggleHide = false
+		-- End mod
 		
 		-- Save initialization status
 		if not FTC.init.Log then
@@ -103,13 +116,56 @@
 		-- Bail if the log is disabled
 		if ( not FTC.Vars.EnableLog ) then return end
 
-		-- Toggle alternating with chat
-		if FTC_CombatLog:IsHidden() then
-			FTC.Log:SetupChat( false )
+		-- Mod High Isle non-alternating combat log 29-08-22
+		-- Manage the toggle for chat alternating and non-chat alternating
+		if FTC.Vars.AlternateChat then
+			-- Toggle alternating with chat
+			if FTC_CombatLog:IsHidden() then
+				FTC.Log:SetupChat( false )
+			else
+				FTC.Log:SetupChat( true )
+			end
 		else
-			FTC.Log:SetupChat( true )
+			if FTC_CombatLog:IsHidden() then
+				-- Was hidden, so reveal
+				FTC_CombatLog:SetHidden(false)
+				FTC.init.toggleHide = false
+			else
+				-- Was visible, so hide
+				FTC_CombatLog:SetHidden(true)
+				FTC.init.toggleHide = true
+			end
 		end
+		--End mod
 	end
+
+	-- Mod High Isle non-alternating combat log 29-08-22
+	--[[ 
+	 * Switch Combat Log visibility on layer change.
+	 * --------------------------------
+	 * Called by FTC.OnLayerChange()
+	 * --------------------------------
+	 ]]--
+	function FTC.Log:ToggleLayer(hide)
+
+		-- Consider change based on request and current toggle state
+		if hide then
+			-- Request to hide - do nothing if already hidden
+			if (FTC_CombatLog:IsHidden()) then return end
+			-- Otherwise hide
+			FTC_CombatLog:SetHidden(true)
+		else
+			-- Request to make visible - do nothing if already visible
+			if (not FTC_CombatLog:IsHidden()) then return end
+			-- Otherwise only allow if previously toggled to visible
+			if (not FTC.init.toggleHide) then 
+				FTC_CombatLog:SetHidden(false) 
+			end
+		end
+
+	end
+	--End mod
+	
 
 	--[[ 
 	 * Print Message to Log


### PR DESCRIPTION
Hi Rhyono, there was an issue with the Combat Log not being hidden when there was a change in the context (layer) from "normal" to map, mail, inventory, etc. The log remained in focus preventing proper access to the desired functions. This was caused in the High Isle update, where the parent of the combat log was changed to GuiRoot, from FTC_UI, which meant that it was excluded from the processing of the event handler OnLayerChange. I extended OnLayerChange to toggle the visibility of the combat log if it was not alternating with chat. This required a new function in log/function.lua to manage the toggle. I also tidied up some of the processing associated with non-alternating logs, also in log/functions.lua.

I had asked on the ESO forum about this issue, and when I said I had a solution Baertram suggested that I create a fork, include my changes, and create a pull request... which is this!