### PR TITLE
Update controls.lua

### DIFF
--- a/character/functions.lua
+++ b/character/functions.lua
@@ -162,7 +162,7 @@ end
             data    = FTC.Target
 
         -- Group
-        elseif ( string.sub(unitTag, 0, 5) == "group" and not (string.find(unitTag, "companion"))) then
+        elseif (  type(unitTag) == "string" and string.sub(unitTag, 0, 5) == "group" and not (string.find(unitTag, "companion"))) then
             local i = GetGroupIndexByUnitTag(unitTag)
             data    = FTC.Group[i]
 
@@ -210,7 +210,7 @@ end
             data    = FTC.Target
 
         -- Group
-        elseif ( string.sub(unitTag, 0, 5) == "group" and not (string.find(unitTag, "companion")) and ( ( GetGroupSize() <= 4 and FTC.Vars.GroupFrames ) or FTC.Vars.RaidFrames ) ) then
+        elseif (  type(unitTag) == "string" and string.sub(unitTag, 0, 5) == "group" and not (string.find(unitTag, "companion")) and ( ( GetGroupSize() <= 4 and FTC.Vars.GroupFrames ) or FTC.Vars.RaidFrames ) ) then
             local i = GetGroupIndexByUnitTag(unitTag)
             data    = FTC.Group[i]
 

--- a/frames/functions.lua
+++ b/frames/functions.lua
@@ -543,7 +543,7 @@
             enabled = FTC.Vars.TargetFrame
 
         -- Group Frames
-        elseif ( string.sub(unitTag, 0, 5) == "group" and ( FTC.Vars.GroupFrames or FTC.Vars.RaidFrames ) ) then
+        elseif ( type(unitTag) == "string" and string.sub(unitTag, 0, 5) == "group" and ( FTC.Vars.GroupFrames or FTC.Vars.RaidFrames ) ) then
 
             -- Get the group member
             local i = GetGroupIndexByUnitTag(unitTag)

--- a/frames/functions.lua
+++ b/frames/functions.lua
@@ -431,7 +431,7 @@
             enabled = FTC.Vars.TargetFrame
 
         -- Group Frames
-        elseif ( string.sub(unitTag, 0, 5) == "group" ) then
+        elseif ( type(unitTag) == "string" and string.sub(unitTag, 0, 5) == "group" ) then
 
             -- Get the group member
             local i = GetGroupIndexByUnitTag(unitTag)

--- a/sct/controls.lua
+++ b/sct/controls.lua
@@ -102,8 +102,8 @@
 	   
 
 	   -- Apply some options
-	   control.value:SetResizeToFitDescendents(true)
-	   control.name:SetResizeToFitDescendents(true)
+	   --control.value:SetResizeToFitDescendents(true)
+	   --control.name:SetResizeToFitDescendents(true)
 
 	    -- Return buff to pool
 	    return control
@@ -131,8 +131,8 @@
 	    control.frame   = FTC.UI:Texture(  "FTC_SCTIn"..counter.."_Frame",  control,   	{size-4,size-4},    {CENTER,CENTER,0,0,control.icon}, 	'/esoui/art/actionbar/icon_metal04.dds', false )
 	   
 	   -- Apply some options
-	   control.value:SetResizeToFitDescendents(true)
-	   control.name:SetResizeToFitDescendents(true)
+	   --control.value:SetResizeToFitDescendents(true)
+	   --control.name:SetResizeToFitDescendents(true)
 
 	    -- Return buff to pool
 	    return control


### PR DESCRIPTION
For update 37, removes calls to control.value:SetResizeToFitDescendents(...). See here: https://www.esoui.com/forums/showthread.php?t=10338