### PR TITLE
Updates for Necrom.

### DIFF
--- a/FoundryTacticalCombat.txt
+++ b/FoundryTacticalCombat.txt
@@ -1,7 +1,7 @@
 ## Title: Foundry Tactical Combat
 ## Description: A combat enhancement addon designed to give players access to relevant combat data in an easy to process framework which allows them to respond quickly and effectively to evolving combat situations.
 ## Version: 1.23
-## APIVersion: 101037 101036
+## APIVersion: 101038
 ## SavedVariables: FTC_VARS
 ## DependsOn: LibAddonMenu-2.0 LibMsgWin-1.0>=10
 ## OptionalDependsOn: UnitFramesRebirth

--- a/character/functions.lua
+++ b/character/functions.lua
@@ -296,7 +296,7 @@ end
      ]]-- 
     function FTC.Player:GetClass(classId)
 		--START
-		local arr = {"Dragonknight", "Scorcerer", "Nightblade", "Warden", "Necromancer", "Templar"}
+		local arr = {"Dragonknight", "Sorcerer", "Nightblade", "Warden", "Necromancer", "Templar", [117]="Arcanist"}
 		return arr[classId]
 		--END
         --if ( classId == 1 ) then return "Dragonknight"


### PR DESCRIPTION
- Added Arcanist class ID.
- Fixed seemingly unintended typo of "Sorcerer"
- Updated API version for Necrom.

Not sure why they jumped to 117 for the class ID, but that seems to be what they did, and FTC fails hard on Arcanist without the mapping.

I tested the "Sorcerer" spelling fix with my sorcerer and it seems to work fine. I will happily remove it if there's a reason to not fix the spelling.