### PR TITLE
Version: 1.29

### DIFF
--- a/FoundryTacticalCombat.lua
+++ b/FoundryTacticalCombat.lua
@@ -17,8 +17,8 @@
     Author:   		Atropos / Philgo68 / Demiknight (Dark Brotherhood) / Rhyono (Homestead/Morrowind/HotR/CC/Dragon Bones/Summerset/Wolfhunter/Murkmire/Wrathstone/Elsweyr/Scalebreaker/Dragonhold/Harrowstorm/Greymoor/Stonethorn/Markarth/FoA/Blackwood/Walking Flame/Deadlands)
 	  Contributors:	decay2 / Scootworks / Hoft / Antisenil / sirinsidiator / mitbulls / fugue / hypatian / Sharlikran
     Email:    		atropos@tamrielfoundry.com
-    Version:  		1.28
-    Updated:  		2023-07-06
+    Version:  		1.29
+    Updated:  		2023-07-12
   ]]--
 
 --[[----------------------------------------------------------
@@ -29,7 +29,7 @@
 FTC.addOnName = "FoundryTacticalCombat"
 FTC.tag = "FTC"
 FTC.modName = "Foundry Tactical Combat"
-FTC.version = 1.28
+FTC.version = 1.29
 FTC.settings = 0.60
 FTC.language = GetCVar("language.2")
 FTC.UI = WINDOW_MANAGER:CreateTopLevelWindow("FTC_UI")

--- a/FoundryTacticalCombat.txt
+++ b/FoundryTacticalCombat.txt
@@ -1,7 +1,7 @@
 ## Title: Foundry Tactical Combat
 ## Description: A combat enhancement addon designed to give players access to relevant combat data in an easy to process framework which allows them to respond quickly and effectively to evolving combat situations.
-## Version: 1.28
-## AddOnVersion: 128
+## Version: 1.29
+## AddOnVersion: 129
 ## APIVersion: 101037 101038
 ## SavedVariables: FTC_VARS
 ## DependsOn: LibAddonMenu-2.0>=34 LibMsgWin-1.0>=11

--- a/buffs/effects.lua
+++ b/buffs/effects.lua
@@ -106,7 +106,7 @@ end
 --[[
  * Identify Taunt Abilities
  * --------------------------------
- * Called by FTC.Player:GetActionBar()
+ * Called by: None, Unused
  * --------------------------------
  ]]--
 function FTC.Buffs:IsTaunt(name)

--- a/character/functions.lua
+++ b/character/functions.lua
@@ -162,6 +162,7 @@ function FTC.Group:GetGroupIndexByUnitTag(unitTag)
       if info.unitTag == unitTag then return FTC.Group[index].groupIndex end
     end
   end
+  return
 end
 
 function FTC.Group:IsUnitTagGroupTag(unitTag)

--- a/character/functions.lua
+++ b/character/functions.lua
@@ -81,12 +81,14 @@ end
  * --------------------------------
  ]]--
 function FTC.Target:Update()
-
   -- Hide default frame
   if (FTC.init.Frames and not FTC.Vars.DefaultTargetFrame) then FTC.TARGET_WINDOW:SetHidden(true) end
 
+  local isCritter = false
+  if FTC.Vars.ignoreCritters then isCritter = FTC:IsCritter('reticleover') end
+
   -- Ignore empty and critters, but not during move mode
-  local ignore = ((not DoesUnitExist('reticleover')) or FTC:IsCritter('reticleover')) and not FTC.move
+  local ignore = ((not DoesUnitExist('reticleover')) or isCritter) and not FTC.move
 
   -- Update valid targets
   if (not ignore) then
@@ -369,8 +371,17 @@ end
  * --------------------------------
  ]]--
 function FTC:IsCritter(unitTag)
-  -- Critters meet all the following criteria: Level 1, Difficulty = NONE, and Neutral or Friendly reaction
-  return ((GetUnitLevel(unitTag) == 1) and (GetUnitDifficulty(unitTag) == MONSTER_DIFFICULTY_NONE) and (GetUnitReaction(unitTag) == UNIT_REACTION_NEUTRAL or GetUnitReaction(unitTag) == UNIT_REACTION_FRIENDLY))
+    -- bail if there is no unitTag
+  if not unitTag then return end
+
+  -- Critters meet all the following criteria: EffectiveLevel 50, Effective Health 1, Difficulty = NONE, and Neutral or Friendly reaction
+  local isBaseLevel = GetUnitEffectiveLevel(unitTag) == 50
+  local _, _, effectiveMaxHealth = GetUnitPower(unitTag, COMBAT_MECHANIC_FLAGS_HEALTH)
+  local hasNegligibleHealth = effectiveMaxHealth == 1
+  local difficultyNone = GetUnitDifficulty(unitTag) == MONSTER_DIFFICULTY_NONE
+  local friendlyOrNeutral = (GetUnitReaction(unitTag) == UNIT_REACTION_NEUTRAL or GetUnitReaction(unitTag) == UNIT_REACTION_FRIENDLY)
+  local isCritter = (isBaseLevel and hasNegligibleHealth and difficultyNone and friendlyOrNeutral)
+  return isCritter
 end
 
 --[[

--- a/core/functions.lua
+++ b/core/functions.lua
@@ -151,4 +151,3 @@ end
 function FTC:Slash(text)
   LAM2:OpenToPanel(FTC_Menu)
 end
-	

--- a/frames/controls.lua
+++ b/frames/controls.lua
@@ -267,7 +267,7 @@ end
     UNIT FRAME ANIMATIONS
   ]]----------------------------------------------------------
 
---[[ 
+--[[
  * Unit Frame Opacity Fading
  * --------------------------------
  * Called by FTC.Frames:Attribute()
@@ -315,7 +315,7 @@ function FTC.Frames:Fade(unitTag, frame)
   timeline:PlayFromStart()
 end
 
---[[ 
+--[[
  * Target Frame Execute Animation
  * --------------------------------
  * Called by FTC.Frames:Attribute()
@@ -343,7 +343,7 @@ function FTC.Frames:Execute()
 end
 
 
---[[ 
+--[[
  * Attribute Regeneration Arrows
  * --------------------------------
  * Called by FTC.OnVisualAdded()

--- a/frames/controls.lua
+++ b/frames/controls.lua
@@ -101,7 +101,7 @@ function FTC.Frames:Controls()
   -- Nameplate
   local plate = FTC.UI:Control("FTC_TargetFrame_Plate", target, { target:GetWidth(), (target:GetHeight() / 4) }, { TOP, TOP, 0, 0 }, false)
   plate.name = FTC.UI:Label("FTC_TargetFrame_PlateName", plate, { plate:GetWidth() - 42, 30 }, { BOTTOMLEFT, BOTTOMLEFT, 6, 0 }, FTC.UI:Font(FTC.Vars.FrameFont1, FTC.Vars.FrameFontSize + 2, true), nil, { 0, 1 }, "Target Name (Level)", false)
-  plate.class = FTC.UI:Texture("FTC_TargetFrame_PlateClass", plate, { 36, 36 }, { BOTTOMRIGHT, BOTTOMRIGHT, 0, 2 }, "/esoui/art/contacts/social_classicon_" .. FTC.Player.class .. ".dds", false)
+  plate.class = FTC.UI:Texture("FTC_TargetFrame_PlateClass", plate, { 36, 36 }, { BOTTOMRIGHT, BOTTOMRIGHT, 0, 2 }, GetClassIcon(GetUnitClassId('player')), false)
   target.plate = plate
 
   -- Health Bar
@@ -115,9 +115,9 @@ function FTC.Frames:Controls()
   target.health = health
 
   -- Execute Indicator
-  local execute = FTC.UI:Texture("FTC_TargetFrame_Execute", health, { 36, 36 }, { CENTER, CENTER, 0, 0 }, '/esoui/art/icons/mapkey/mapkey_groupboss.dds', true)
-  execute:SetDrawLayer(1)
-  target.execute = execute
+  local executeTarget = FTC.UI:Texture("FTC_TargetFrame_Execute", health, { 36, 36 }, { CENTER, CENTER, 0, 0 }, '/esoui/art/icons/mapkey/mapkey_groupboss.dds', true)
+  executeTarget:SetDrawLayer(1)
+  target.executeTarget = executeTarget
 
   -- Titleplate
   local lplate = FTC.UI:Control("FTC_TargetFrame_LPlate", target, { target:GetWidth(), (target:GetHeight() / 4) }, { TOP, BOTTOM, 0, 6, target.health }, false)
@@ -152,7 +152,7 @@ function FTC.Frames:Controls()
 
   -- Iterate over four group members
   local anchor = { TOP, TOP, 0, 0, group }
-  for i = 1, 4 do
+  for i = 1, STANDARD_GROUP_SIZE_THRESHOLD do
     local member = FTC.UI:Control("FTC_GroupFrame" .. i, group, { FTC.Vars.GroupWidth, FTC.Vars.GroupHeight / 4 }, anchor, true)
     member:SetAlpha(FTC.Vars.FrameOpacityIn / 100)
 
@@ -160,7 +160,7 @@ function FTC.Frames:Controls()
     local plate = FTC.UI:Control("FTC_GroupFrame" .. i .. "_Plate", member, { member:GetWidth(), member:GetHeight() / 3 }, { TOP, TOP, 0, 0 }, false)
     plate.icon = FTC.UI:Texture("FTC_GroupFrame" .. i .. "_Icon", plate, { 24, 24 }, { BOTTOMLEFT, BOTTOMLEFT, 0, 0 }, "/esoui/art/lfg/lfg_leader_icon.dds", false)
     plate.name = FTC.UI:Label("FTC_GroupFrame" .. i .. "_Name", plate, { plate:GetWidth() - 24, plate:GetHeight() }, { LEFT, RIGHT, 6, 0, plate.icon }, FTC.UI:Font(FTC.Vars.FrameFont1, FTC.Vars.GroupFontSize, true), nil, { 0, 1 }, "Member " .. i, false)
-    plate.class = FTC.UI:Texture("FTC_GroupFrame" .. i .. "_Class", plate, { 24, 24 }, { BOTTOMRIGHT, BOTTOMRIGHT, 0, 0 }, "/esoui/art/contacts/social_classicon_" .. FTC.Player.class .. ".dds", false)
+    plate.class = FTC.UI:Texture("FTC_GroupFrame" .. i .. "_Class", plate, { 24, 24 }, { BOTTOMRIGHT, BOTTOMRIGHT, 0, 0 }, GetClassIcon(GetUnitClassId('player')), false)
     member.plate = plate
 
     -- Health bar
@@ -214,7 +214,7 @@ function FTC.Frames:Controls()
 
   -- Iterate over 24 possible raid members
   local anchor = { TOPLEFT, TOPLEFT, 0, 0, raid }
-  for i = 1, 24 do
+  for i = 1, LARGE_GROUP_SIZE_THRESHOLD do
     local member = FTC.UI:Control("FTC_RaidFrame" .. i, raid, { FTC.Vars.RaidWidth, FTC.Vars.RaidHeight }, anchor, true)
     member:SetAlpha(FTC.Vars.FrameOpacityIn / 100)
 
@@ -270,7 +270,8 @@ end
 --[[
  * Unit Frame Opacity Fading
  * --------------------------------
- * Called by FTC.Frames:Attribute()
+ * Called by FTC.Frames:SafetyCheck()
+ * Called by FTC.OnCombatState()
  * --------------------------------
  ]]--
 FTC.Frames.resetAnim = false

--- a/frames/functions.lua
+++ b/frames/functions.lua
@@ -12,6 +12,7 @@ FTC.Frames.Defaults = {
   ["LabelFrames"] = false,
   ["GroupFrames"] = true,
   ["RaidFrames"] = true,
+  ["ignoreCritters"] = true,
 
   -- Roles
   [LFG_ROLE_INVALID] = "Default",

--- a/frames/functions.lua
+++ b/frames/functions.lua
@@ -56,7 +56,7 @@ FTC.Frames.Defaults = {
   ["FrameTankColor"] = { 133 / 255, 018 / 255, 013 / 255 },
   ["FrameHealerColor"] = { 117 / 255, 077 / 255, 135 / 255 },
   ["FrameDamageColor"] = { 255 / 255, 196 / 255, 128 / 255 },
-  ["FrameCompanionColor"] = { 133 / 255, 018 / 255, 013 / 255 },
+  ["FrameCompanionColor"] = { 255 / 255, 104 / 255, 97 / 255 },
   ["GroupShowLevel"] = true,
 
   -- Raid Frame
@@ -361,7 +361,7 @@ function FTC.Frames:SetupGroup()
         local label = (context == "Group" and FTC.Vars.GroupShowLevel) and name .. " (" .. level .. ")" or name
         frame.plate.name:SetText(label)
 
-        -- Do not Populate raid or group class or leader icon because it's a companion
+        -- Hide icon because it's a companion
         frame.plate.icon:SetWidth(0)
         frame.plate.icon:SetHidden(true)
 
@@ -403,7 +403,7 @@ function FTC.Frames:SetupGroup()
       local label = (context == "Group" and FTC.Vars.GroupShowLevel) and name .. " (" .. level .. ")" or name
       frame.plate.name:SetText(label)
 
-      -- Hide companion icon
+      -- Hide icon because it's a companion
       frame.plate.icon:SetWidth(0)
       frame.plate.class:SetHidden(true)
 
@@ -464,6 +464,9 @@ function FTC.Frames:GroupRange(unitTag, inRange)
 
   local currentUnitTag = FTC.Group[index].unitTag
   local frame = _G["FTC_" .. context .. "Frame" .. index]
+
+  -- bail if there is no frame
+  if not frame then return end
 
   -- If a range status was not passed, retrieve it
   if (inRange == nil) then inRange = IsUnitInGroupSupportRange(currentUnitTag) end
@@ -574,6 +577,8 @@ function FTC.Frames:Attribute(unitTag, attribute, powerValue, powerMax, pct, shi
     -- Otherwise bail
   else return end
 
+  -- bail if there is no frame
+  if not frame then return end
 
   -- Compute data
   if (enabled or (FTC.Vars.LabelFrames and default ~= nil)) then
@@ -628,7 +633,7 @@ function FTC.Frames:Attribute(unitTag, attribute, powerValue, powerMax, pct, shi
 
       -- Maybe prompt for execute
       if (currentUnitTag == 'reticleover') then
-        frame.execute:SetHidden(not (pct < FTC.Vars.ExecuteThreshold / 100))
+        frame.executeTarget:SetHidden(not (pct < FTC.Vars.ExecuteThreshold / 100))
         if ((not IsUnitDead(currentUnitTag)) and (pct < FTC.Vars.ExecuteThreshold / 100) and (FTC.Target.health.pct > FTC.Vars.ExecuteThreshold / 100)) then FTC.Frames:Execute() end
       end
     end
@@ -931,17 +936,22 @@ function FTC.Frames:SafetyCheck()
     FTC.Frames:Fade('player', FTC_PlayerFrame)
   end
 
-  -- Group frames
-  if (IsUnitGrouped('player')) then
-    local context = nil
-    if (FTC.Group.groupSize <= STANDARD_GROUP_SIZE_THRESHOLD and FTC.Vars.GroupFrames) then context = "Group"
-    elseif (FTC.Vars.RaidFrames) then context = "Raid"
-    else return end
+  -- loop over group members and update health
+  for groupSizeIndex = 1, FTC.Group.groupSize do
+    local unitTag = GetGroupUnitTagByIndex(groupSizeIndex)
+    if DoesUnitExist(unitTag) and not IsUnitInCombat(unitTag) then
+      FTC.Player:UpdateAttribute(unitTag, COMBAT_MECHANIC_FLAGS_HEALTH, nil, nil, nil)
+      FTC.Frames:GroupRange(unitTag, nil)
+    end
+  end
 
-    -- Update attributes out of combat
-    for i = 1, GetGroupSize() do
-      if (not IsUnitInCombat('player')) then FTC.Player:UpdateAttribute(GetGroupUnitTagByIndex(i), COMBAT_MECHANIC_FLAGS_HEALTH, nil, nil, nil) end
-      FTC.Frames:GroupRange('group' .. i, nil)
+  -- loop over companions and update health
+  for groupSizeIndex = 1, FTC.Group.groupSize do
+    local unitTag = GetGroupUnitTagByIndex(groupSizeIndex)
+    local companionUnitTag = GetCompanionUnitTagByGroupUnitTag(unitTag)
+    if DoesUnitExist(companionUnitTag) and not IsUnitInCombat(companionUnitTag) then
+      FTC.Player:UpdateAttribute(companionUnitTag, COMBAT_MECHANIC_FLAGS_HEALTH, nil, nil, nil)
+      FTC.Frames:GroupRange(companionUnitTag, nil)
     end
   end
 end

--- a/hotbar/functions.lua
+++ b/hotbar/functions.lua
@@ -41,6 +41,12 @@ function FTC.Hotbar:UpdateUltimate(current, cost)
   FTC_UltimatePct:SetText((math.floor((current / cost) * 100)) .. "%")
 end
 
+--[[
+ *
+ * --------------------------------
+ * Called by FTC.Damage:New()
+ * --------------------------------
+ ]]--
 function FTC.Hotbar:UltimateBuff(damage)
 
   -- Bail if it's not a correct trigger

--- a/lang/de.lua
+++ b/lang/de.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1] * 255) .. "," .. mat
 ZO_CreateStringId("FTC_Menu_FDamageC", "Farbeinstellung DD Rolle")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc", "Die eingestellte Farbe für die Damage Dealer wird im Gruppen- und Schlachtzugsfenster angezeigt. [Standard: " .. default .. "]")
 
+local default = math.floor(FTC.Defaults.FrameCompanionColor[1] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[2] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[3] * 255)
+ZO_CreateStringId("FTC_Menu_FCompanionC", "Companion Healthbar Color")
+ZO_CreateStringId("FTC_Menu_FCompanionCDesc", "Set the color displayed for the Companion Healthbar in FTC Group and Raid frames. [Default: " .. default .. "]")
+
 local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Enable Raid Frames")
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Use custom unit frames for groups of size 4 or more? [Default: " .. default .. "]")

--- a/lang/de.lua
+++ b/lang/de.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1] * 255) .. "," .. mat
 ZO_CreateStringId("FTC_Menu_FDamageC", "Farbeinstellung DD Rolle")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc", "Die eingestellte Farbe für die Damage Dealer wird im Gruppen- und Schlachtzugsfenster angezeigt. [Standard: " .. default .. "]")
 
+local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Enable Raid Frames")
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Use custom unit frames for groups of size 4 or more? [Default: " .. default .. "]")
+
 local default = (FTC.Defaults.EnableRaidFrames) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_FRaid", "Schlachtzugsfenster aktivieren")
 ZO_CreateStringId("FTC_Menu_FRaidDesc", "Das Schlachtzugsfenster wird bei einer Gruppengröße größer als 4 angezeigt. [Standard: " .. default .. "]")

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1] * 255) .. "," .. mat
 ZO_CreateStringId("FTC_Menu_FDamageC", "Damage Role Color")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc", "Set the color displayed for DPS in FTC group and raid frames. [Default: " .. default .. "]")
 
+local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Ignore Critters")
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Ignore Critters with custom target frame? [Default: " .. default .. "]")
+
 local default = (FTC.Defaults.EnableRaidFrames) and "Enabled" or "Disabled"
 ZO_CreateStringId("FTC_Menu_FRaid", "Enable Raid Frames")
 ZO_CreateStringId("FTC_Menu_FRaidDesc", "Use custom unit frames for groups of size 4 or more? [Default: " .. default .. "]")

--- a/lang/en.lua
+++ b/lang/en.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1] * 255) .. "," .. mat
 ZO_CreateStringId("FTC_Menu_FDamageC", "Damage Role Color")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc", "Set the color displayed for DPS in FTC group and raid frames. [Default: " .. default .. "]")
 
+local default = math.floor(FTC.Defaults.FrameCompanionColor[1] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[2] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[3] * 255)
+ZO_CreateStringId("FTC_Menu_FCompanionC", "Companion Healthbar Color")
+ZO_CreateStringId("FTC_Menu_FCompanionCDesc", "Set the color displayed for the Companion Healthbar in FTC Group and Raid frames. [Default: " .. default .. "]")
+
 local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Ignore Critters")
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Ignore Critters with custom target frame? [Default: " .. default .. "]")

--- a/lang/fr.lua
+++ b/lang/fr.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1]*255)..","..math.floo
 ZO_CreateStringId("FTC_Menu_FDamageC",      "Couleur du DPS")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc",  "Régler la couleur affichée pour les DPS dans les cadres de groupe et raid de FTC [Défaut: "..default.."]")
 
+local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Enable Raid Frames")
+ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Use custom unit frames for groups of size 4 or more? [Default: " .. default .. "]")
+
 local default = ( FTC.Defaults.EnableRaidFrames ) and "Activé" or "Désactivé"
 ZO_CreateStringId("FTC_Menu_FRaid",         "Activer Cadres de Raid")
 ZO_CreateStringId("FTC_Menu_FRaidDesc",     "Utiliser les cadres unitaires customisés pour les groupes de quatre ou plus? [Défaut: "..default.."]")

--- a/lang/fr.lua
+++ b/lang/fr.lua
@@ -202,6 +202,10 @@ local default = math.floor(FTC.Defaults.FrameDamageColor[1]*255)..","..math.floo
 ZO_CreateStringId("FTC_Menu_FDamageC",      "Couleur du DPS")
 ZO_CreateStringId("FTC_Menu_FDamageCDesc",  "Régler la couleur affichée pour les DPS dans les cadres de groupe et raid de FTC [Défaut: "..default.."]")
 
+local default = math.floor(FTC.Defaults.FrameCompanionColor[1] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[2] * 255) .. "," .. math.floor(FTC.Defaults.FrameCompanionColor[3] * 255)
+ZO_CreateStringId("FTC_Menu_FCompanionC", "Companion Healthbar Color")
+ZO_CreateStringId("FTC_Menu_FCompanionCDesc", "Set the color displayed for the Companion Healthbar in FTC Group and Raid frames. [Default: " .. default .. "]")
+
 local default = (FTC.Defaults.ignoreCritters) and "Enabled" or "Disabled"
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_NAME", "Enable Raid Frames")
 ZO_CreateStringId("FTC_MENU_IGNORE_CRITTERS_DESC", "Use custom unit frames for groups of size 4 or more? [Default: " .. default .. "]")

--- a/menu/controls.lua
+++ b/menu/controls.lua
@@ -608,6 +608,19 @@ function FTC.Menu:Controls()
       default = FTC.Vars.FrameDamageColor,
     }
 
+    -- Companion Healthbar Color
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
+      name = GetString(FTC_Menu_FCompanionC),
+      tooltip = GetString(FTC_Menu_FCompanionCDesc),
+      getFunc = function() return unpack(FTC.Vars.FrameCompanionColor) end,
+      setFunc = function(r, g, b, a)
+        FTC.Vars.FrameCompanionColor = FTC.Menu:CreateColorTable(r, g, b, a)
+        FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
+      end,
+      default = FTC.Vars.FrameCompanionColor,
+    }
+
     -- Raid Column Size
     FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "dropdown",

--- a/menu/controls.lua
+++ b/menu/controls.lua
@@ -36,169 +36,195 @@ function FTC.Menu:Controls()
   --[[----------------------------------------------------------
       SELECT CORE COMPONENTS
     ]]----------------------------------------------------------
-  FTC.Menu.options = {
+  FTC.Menu.options = {}
 
-    -- Components Header
-    { type = "header",
-      name = GetString(FTC_Menu_Configure),
-      width = "full"
-    },
-
-    -- Enable/Disable Unit Frames
-    { type = "checkbox",
-      name = GetString(FTC_Menu_Frames),
-      tooltip = GetString(FTC_Menu_FramesDesc),
-      getFunc = function() return FTC.Vars.EnableFrames end,
-      setFunc = function(value) FTC.Menu:Update('EnableFrames', value, true) end,
-      default = FTC.Defaults.EnableFrames,
-      requiresReload = true,
-    },
-
-    -- Enable/Disable Buff Tracking
-    { type = "checkbox",
-      name = GetString(FTC_Menu_Buffs),
-      tooltip = GetString(FTC_Menu_BuffsDesc),
-      getFunc = function() return FTC.Vars.EnableBuffs end,
-      setFunc = function(value) FTC.Menu:Update('EnableBuffs', value, true) end,
-      default = FTC.Defaults.EnableBuffs,
-      requiresReload = true,
-    },
-
-    -- Enable/Disable Combat Log
-    { type = "checkbox",
-      name = GetString(FTC_Menu_Log),
-      tooltip = GetString(FTC_Menu_LogDesc),
-      getFunc = function() return FTC.Vars.EnableLog end,
-      setFunc = function(value) FTC.Menu:Update('EnableLog', value, true) end,
-      default = FTC.Defaults.EnableLog,
-      requiresReload = true,
-    },
-
-    -- Enable/Disable Scrolling Combat Text
-    { type = "checkbox",
-      name = GetString(FTC_Menu_SCT),
-      tooltip = GetString(FTC_Menu_SCTDesc),
-      getFunc = function() return FTC.Vars.EnableSCT end,
-      setFunc = function(value) FTC.Menu:Update('EnableSCT', value, true) end,
-      default = FTC.Defaults.EnableSCT,
-      requiresReload = true,
-    },
-
-    -- Enable/Disable Damage Statistics
-    { type = "checkbox",
-      name = GetString(FTC_Menu_Stats),
-      tooltip = GetString(FTC_Menu_StatsDesc),
-      getFunc = function() return FTC.Vars.EnableStats end,
-      setFunc = function(value) FTC.Menu:Update('EnableStats', value, true) end,
-      default = FTC.Defaults.EnableStats,
-      requiresReload = true,
-    },
-
-    -- Enable/Disable Advanced Hotbar
-    { type = "checkbox",
-      name = GetString(FTC_Menu_Hotbar),
-      tooltip = GetString(FTC_Menu_HotbarDesc),
-      getFunc = function() return FTC.Vars.EnableHotbar end,
-      setFunc = function(value) FTC.Menu:Update('EnableHotbar', value, true) end,
-      default = FTC.Defaults.EnableHotbar,
-      requiresReload = true,
-    },
-
-    -- Reposition Elements?
-    {
-      type = "button",
-      name = GetString(FTC_Menu_Move),
-      tooltip = GetString(FTC_Menu_MoveDesc),
-      func = function() FTC.Menu:MoveFrames(true) end,
-    },
-
-    -- Reset Unit Frames
-    {
-      type = "button",
-      name = GetString(FTC_Menu_Reset),
-      tooltip = GetString(FTC_Menu_ResetDesc),
-      func = function() FTC.Menu:Reset() end,
-    },
+  -- Components Header
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "header",
+    name = GetString(FTC_Menu_Configure),
+    width = "full"
   }
+
+  -- Enable/Disable Unit Frames
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_Frames),
+    tooltip = GetString(FTC_Menu_FramesDesc),
+    getFunc = function() return FTC.Vars.EnableFrames end,
+    setFunc = function(value) FTC.Menu:Update('EnableFrames', value, true) end,
+    default = FTC.Defaults.EnableFrames,
+    requiresReload = true,
+  }
+
+  -- Enable/Disable Buff Tracking
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_Buffs),
+    tooltip = GetString(FTC_Menu_BuffsDesc),
+    getFunc = function() return FTC.Vars.EnableBuffs end,
+    setFunc = function(value) FTC.Menu:Update('EnableBuffs', value, true) end,
+    default = FTC.Defaults.EnableBuffs,
+    requiresReload = true,
+  }
+
+  -- Enable/Disable Combat Log
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_Log),
+    tooltip = GetString(FTC_Menu_LogDesc),
+    getFunc = function() return FTC.Vars.EnableLog end,
+    setFunc = function(value) FTC.Menu:Update('EnableLog', value, true) end,
+    default = FTC.Defaults.EnableLog,
+    requiresReload = true,
+  }
+
+  -- Enable/Disable Scrolling Combat Text
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_SCT),
+    tooltip = GetString(FTC_Menu_SCTDesc),
+    getFunc = function() return FTC.Vars.EnableSCT end,
+    setFunc = function(value) FTC.Menu:Update('EnableSCT', value, true) end,
+    default = FTC.Defaults.EnableSCT,
+    requiresReload = true,
+  }
+
+  -- Enable/Disable Damage Statistics
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_Stats),
+    tooltip = GetString(FTC_Menu_StatsDesc),
+    getFunc = function() return FTC.Vars.EnableStats end,
+    setFunc = function(value) FTC.Menu:Update('EnableStats', value, true) end,
+    default = FTC.Defaults.EnableStats,
+    requiresReload = true,
+  }
+
+  -- Enable/Disable Advanced Hotbar
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "checkbox",
+    name = GetString(FTC_Menu_Hotbar),
+    tooltip = GetString(FTC_Menu_HotbarDesc),
+    getFunc = function() return FTC.Vars.EnableHotbar end,
+    setFunc = function(value) FTC.Menu:Update('EnableHotbar', value, true) end,
+    default = FTC.Defaults.EnableHotbar,
+    requiresReload = true,
+  }
+
+  -- Reposition Elements?
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "button",
+    name = GetString(FTC_Menu_Move),
+    tooltip = GetString(FTC_Menu_MoveDesc),
+    func = function() FTC.Menu:MoveFrames(true) end,
+  }
+
+  -- Reset Unit Frames
+  FTC.Menu.options[#FTC.Menu.options + 1] = {
+    type = "button",
+    name = GetString(FTC_Menu_Reset),
+    tooltip = GetString(FTC_Menu_ResetDesc),
+    func = function() FTC.Menu:Reset() end,
+  }
+
 
   --[[----------------------------------------------------------
       UNIT FRAMES
     ]]----------------------------------------------------------
-  local Frames = {
 
-    -- Unit Frames Header
-    { type = "header",
+  -- Unit Frames Header
+  if FTC.Vars.EnableFrames then
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "header",
       name = GetString(FTC_Menu_FHeader),
       width = "full"
-    },
+    }
 
     -- Use Player Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FPlayerF),
       tooltip = GetString(FTC_Menu_FPlayerFDesc),
       getFunc = function() return FTC.Vars.PlayerFrame end,
       setFunc = function(value) FTC.Menu:Update('PlayerFrame', value, true) end,
       default = FTC.Defaults.PlayerFrame,
       requiresReload = true,
-    },
+    }
 
     -- Use Target Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FTargetF),
       tooltip = GetString(FTC_Menu_FTargetFDesc),
       getFunc = function() return FTC.Vars.TargetFrame end,
       setFunc = function(value) FTC.Menu:Update('TargetFrame', value) end,
       default = FTC.Defaults.TargetFrame,
-    },
+    }
 
     -- Use Small Group Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FGroup),
       tooltip = GetString(FTC_Menu_FGroupDesc),
       getFunc = function() return FTC.Vars.GroupFrames end,
       setFunc = function(value) FTC.Menu:Update('GroupFrames', value, true) end,
       default = FTC.Defaults.GroupFrames,
       requiresReload = true,
-    },
+    }
     -- Use Raid Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FRaid),
       tooltip = GetString(FTC_Menu_FRaidDesc),
       getFunc = function() return FTC.Vars.RaidFrames end,
       setFunc = function(value) FTC.Menu:Update('RaidFrames', value, true) end,
       default = FTC.Defaults.RaidFrames,
       requiresReload = true,
-    },
+    }
+
+    -- Ignore Critters?
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
+      name = GetString(FTC_MENU_IGNORE_CRITTERS_NAME),
+      tooltip = GetString(FTC_MENU_IGNORE_CRITTERS_DESC),
+      getFunc = function() return FTC.Vars.ignoreCritters end,
+      setFunc = function(value) FTC.Vars.ignoreCritters = value end,
+      default = FTC.Defaults.ignoreCritters,
+    }
 
     -- Keep Default Target Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FShowDef),
       tooltip = GetString(FTC_Menu_FShowDefDesc),
       getFunc = function() return FTC.Vars.DefaultTargetFrame end,
       setFunc = function(value) FTC.Menu:Update('DefaultTargetFrame', value) end,
       default = FTC.Defaults.DefaultTargetFrame
-    },
+    }
 
     -- Label Default Frames?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FLabelDef),
       tooltip = GetString(FTC_Menu_FLabelDefDesc),
       getFunc = function() return FTC.Vars.LabelFrames end,
       setFunc = function(value) FTC.Menu:UpdateFrames('LabelFrames', value) end,
       default = FTC.Defaults.LabelFrames
-    },
+    }
 
     -- Show Maximum Health?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FShowMax),
       tooltip = GetString(FTC_Menu_FShowMaxDesc),
       getFunc = function() return FTC.Vars.FrameShowMax end,
       setFunc = function(value) FTC.Menu:UpdateFrames('FrameShowMax', value) end,
       default = FTC.Defaults.FrameShowMax
-    },
+    }
 
     -- Unit Frame Width
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FWidth),
       tooltip = GetString(FTC_Menu_FWidthDesc),
       min = 200,
@@ -207,10 +233,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameWidth end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameWidth", value) end,
       default = FTC.Defaults.FrameWidth,
-    },
+    }
 
     -- Unit Frame Height
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FHeight),
       tooltip = GetString(FTC_Menu_FHeightDesc),
       min = 120,
@@ -219,10 +246,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameHeight end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameHeight", value) end,
       default = FTC.Defaults.FrameHeight,
-    },
+    }
 
     -- Target Frame Width
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_TFWidth),
       tooltip = GetString(FTC_Menu_TFWidthDesc),
       min = 200,
@@ -231,10 +259,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.TargetFrameWidth end,
       setFunc = function(value) FTC.Menu:UpdateFrames("TargetFrameWidth", value) end,
       default = FTC.Defaults.TargetFrameWidth,
-    },
+    }
 
     -- Target Frame Height
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_TFHeight),
       tooltip = GetString(FTC_Menu_TFHeightDesc),
       min = 80,
@@ -243,10 +272,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.TargetFrameHeight end,
       setFunc = function(value) FTC.Menu:UpdateFrames("TargetFrameHeight", value) end,
       default = FTC.Defaults.TargetFrameHeight,
-    },
+    }
 
     -- In-Combat Opacity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FOpacIn),
       tooltip = GetString(FTC_Menu_FOpacInDesc),
       min = 0,
@@ -255,10 +285,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameOpacityIn end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameOpacityIn", value) end,
       default = FTC.Defaults.OpacityIn
-    },
+    }
 
     -- Non-Combat Opacity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FOpacOut),
       tooltip = GetString(FTC_Menu_FOpacOutDesc),
       min = 0,
@@ -267,10 +298,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameOpacityOut end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameOpacityOut", value) end,
       default = FTC.Defaults.OpacityOut
-    },
+    }
 
     -- In-Combat Target Opacity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FTOpacIn),
       tooltip = GetString(FTC_Menu_FTOpacInDesc),
       min = 0,
@@ -279,10 +311,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameTargetOpacityIn end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameTargetOpacityIn", value) end,
       default = FTC.Defaults.FrameTargetOpacityIn
-    },
+    }
 
     -- Non-Combat Target Opacity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FTOpacOut),
       tooltip = GetString(FTC_Menu_FTOpacOutDesc),
       min = 0,
@@ -291,30 +324,33 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameTargetOpacityOut end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameTargetOpacityOut", value) end,
       default = FTC.Defaults.FrameTargetOpacityOut
-    },
+    }
 
     -- Primary Frame Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_FFont1),
       tooltip = GetString(FTC_Menu_FFont1Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.FrameFont1) end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameFont1", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.FrameFont1,
-    },
+    }
 
     -- Secondary Frame Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_FFont2),
       tooltip = GetString(FTC_Menu_FFont2Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.FrameFont2) end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameFont2", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.FrameFont2,
-    },
+    }
 
     -- Frame Font Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FFontS),
       tooltip = GetString(FTC_Menu_FFontSDesc),
       min = 12,
@@ -323,10 +359,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.FrameFontSize end,
       setFunc = function(value) FTC.Menu:UpdateFrames("FrameFontSize", value) end,
       default = FTC.Defaults.FrameFontSize
-    },
+    }
 
     -- Execute Threshold
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_Exceute),
       tooltip = GetString(FTC_Menu_ExecuteDesc),
       min = 0,
@@ -335,56 +372,62 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.ExecuteThreshold end,
       setFunc = function(value) FTC.Menu:Update("ExecuteThreshold", value) end,
       default = FTC.Defaults.ExecuteThreshold
-    },
+    }
 
     -- Display Nameplate?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FShowName),
       tooltip = GetString(FTC_Menu_FShowNameDesc),
       getFunc = function() return FTC.Vars.EnableNameplate end,
       setFunc = function(value) FTC.Menu:UpdateFrames('EnableNameplate', value) end,
       default = FTC.Defaults.EnableNameplate
-    },
+    }
 
     -- Display Experience Bar?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FShowXP),
       tooltip = GetString(FTC_Menu_FShowXPDesc),
       getFunc = function() return FTC.Vars.EnableXPBar end,
       setFunc = function(value) FTC.Menu:UpdateFrames('EnableXPBar', value) end,
       default = FTC.Defaults.EnableXPBar
-    },
+    }
 
     -- Show Level on Target Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FTargetL),
       tooltip = GetString(FTC_Menu_FTargetLDesc),
       getFunc = function() return FTC.Vars.TargetFrameLevel end,
       setFunc = function(value) FTC.Menu:UpdateFrames('TargetFrameLevel', value) end,
       default = FTC.Defaults.TargetFrameLevel
-    },
+    }
 
     -- Show Titles on Target Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FTargetT),
       tooltip = GetString(FTC_Menu_FTargetTDesc),
       getFunc = function() return FTC.Vars.TargetFrameTitle end,
       setFunc = function(value) FTC.Menu:Update('TargetFrameTitle', value, true) end,
       default = FTC.Defaults.TargetFrameTitle,
       requiresReload = true,
-    },
+    }
 
     -- Show @Name in Target Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FTargetShowA),
       tooltip = GetString(FTC_Menu_FTargetShowADesc),
       getFunc = function() return FTC.Vars.TargetFrameShowAccount end,
       setFunc = function(value) FTC.Menu:UpdateFrames('TargetFrameShowAccount', value) end,
       default = FTC.Defaults.TargetFrameShowAccount
-    },
+    }
 
     -- Font Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FFontC),
       tooltip = GetString(FTC_Menu_FFontCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameFontColor) end,
@@ -393,10 +436,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameFontColor,
-    },
+    }
 
     -- Health Bar Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FHealthC),
       tooltip = GetString(FTC_Menu_FHealthCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameHealthColor) end,
@@ -405,10 +449,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameHealthColor,
-    },
+    }
 
     -- Magicka Bar Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FMagickaC),
       tooltip = GetString(FTC_Menu_FMagickaCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameMagickaColor) end,
@@ -417,10 +462,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameMagickaColor,
-    },
+    }
 
     -- Stamina Bar Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FStaminaC),
       tooltip = GetString(FTC_Menu_FStaminaCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameStaminaColor) end,
@@ -429,10 +475,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameStaminaColor,
-    },
+    }
 
     -- Shield Bar Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FShieldC),
       tooltip = GetString(FTC_Menu_FShieldCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameShieldColor) end,
@@ -441,10 +488,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameShieldColor,
-    },
+    }
 
     -- Group Frame Width
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FGWidth),
       tooltip = GetString(FTC_Menu_FGWidthDesc),
       min = 150,
@@ -453,10 +501,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.GroupWidth end,
       setFunc = function(value) FTC.Menu:UpdateFrames("GroupWidth", value) end,
       default = FTC.Defaults.GroupWidth,
-    },
+    }
 
     -- Group Frame Height
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FGHeight),
       tooltip = GetString(FTC_Menu_FGHeightDesc),
       min = 250,
@@ -465,10 +514,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.GroupHeight end,
       setFunc = function(value) FTC.Menu:UpdateFrames("GroupHeight", value) end,
       default = FTC.Defaults.GroupHeight,
-    },
+    }
 
     -- Group Frame Font Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FGFontS),
       tooltip = GetString(FTC_Menu_FGFontSDesc),
       min = 12,
@@ -477,46 +527,51 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.GroupFontSize end,
       setFunc = function(value) FTC.Menu:UpdateFrames("GroupFontSize", value) end,
       default = FTC.Defaults.GroupFontSize
-    },
+    }
 
     -- Show Player in Group Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FGHideP),
       tooltip = GetString(FTC_Menu_FGHidePDesc),
       getFunc = function() return FTC.Vars.GroupHidePlayer end,
       setFunc = function(value) FTC.Menu:UpdateFrames('GroupHidePlayer', value) end,
       default = FTC.Defaults.GroupHidePlayer
-    },
+    }
 
     -- Show Level in Group Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FGShowL),
       tooltip = GetString(FTC_Menu_FGShowLDesc),
       getFunc = function() return FTC.Vars.GroupShowLevel end,
       setFunc = function(value) FTC.Menu:UpdateFrames('GroupShowLevel', value) end,
       default = FTC.Defaults.GroupShowLevel
-    },
+    }
 
     -- Show @Name in Group Frame?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FGShowA),
       tooltip = GetString(FTC_Menu_FGShowADesc),
       getFunc = function() return FTC.Vars.GroupShowAccount end,
       setFunc = function(value) FTC.Menu:UpdateFrames('GroupShowAccount', value) end,
       default = FTC.Defaults.GroupShowAccount
-    },
+    }
 
     -- Colorize Roles?
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_FColorR),
       tooltip = GetString(FTC_Menu_FColorRDesc),
       getFunc = function() return FTC.Vars.ColorRoles end,
       setFunc = function(value) FTC.Menu:UpdateFrames('ColorRoles', value) end,
       default = FTC.Defaults.ColorRoles
-    },
+    }
 
     -- Tank Role Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FTankC),
       tooltip = GetString(FTC_Menu_FTankCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameTankColor) end,
@@ -525,10 +580,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameTankColor,
-    },
+    }
 
     -- Healer Role Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FHealerC),
       tooltip = GetString(FTC_Menu_FHealerCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameHealerColor) end,
@@ -537,10 +593,11 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameHealerColor,
-    },
+    }
 
     -- DPS Role Color
-    { type = "colorpicker",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "colorpicker",
       name = GetString(FTC_Menu_FDamageC),
       tooltip = GetString(FTC_Menu_FDamageCDesc),
       getFunc = function() return unpack(FTC.Vars.FrameDamageColor) end,
@@ -549,20 +606,22 @@ function FTC.Menu:Controls()
         FTC.Menu:UpdateFrames(nil, nil) -- if both are nil it won't update the value
       end,
       default = FTC.Vars.FrameDamageColor,
-    },
+    }
 
     -- Raid Column Size
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_FRaidS),
       tooltip = GetString(FTC_Menu_FRaidSDesc),
       choices = { 4, 6, },
       getFunc = function() return FTC.Vars.RaidColumnSize end,
       setFunc = function(value) FTC.Menu:UpdateFrames("RaidColumnSize", value) end,
       default = FTC.Defaults.RaidColumnSize,
-    },
+    }
 
     -- Raid Frame Width
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FRWidth),
       tooltip = GetString(FTC_Menu_FRWidthDesc),
       min = 90,
@@ -571,10 +630,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.RaidWidth end,
       setFunc = function(value) FTC.Menu:UpdateFrames("RaidWidth", value) end,
       default = FTC.Defaults.RaidWidth,
-    },
+    }
 
     -- Raid Frame Height
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FRHeight),
       tooltip = GetString(FTC_Menu_FRHeightDesc),
       min = 40,
@@ -583,10 +643,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.RaidHeight end,
       setFunc = function(value) FTC.Menu:UpdateFrames("RaidHeight", value) end,
       default = FTC.Defaults.RaidHeight,
-    },
+    }
 
     -- Raid Frame Font Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_FRFontS),
       tooltip = GetString(FTC_Menu_FRFontSDesc),
       min = 10,
@@ -595,103 +656,110 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.RaidFontSize end,
       setFunc = function(value) FTC.Menu:UpdateFrames("RaidFontSize", value) end,
       default = FTC.Defaults.RaidFontSize
-    },
+    }
 
     -- Reset Unit Frames
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "button",
       name = GetString(FTC_Menu_FReset),
       tooltip = GetString(FTC_Menu_FResetDesc),
       func = function() FTC.Menu:Reset("Frames") end,
-    },
-  }
-  if FTC.Vars.EnableFrames then
-    for i = 1, #Frames do table.insert(FTC.Menu.options, Frames[i]) end
+    }
   end
 
   --[[----------------------------------------------------------
       BUFF TRACKING
     ]]----------------------------------------------------------
-  local Buffs = {
+  if FTC.Vars.EnableBuffs then
+
 
     -- Buff Tracking Header
-    { type = "header",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "header",
       name = GetString(FTC_Menu_BHeader),
       width = "full"
-    },
+    }
 
     -- Player Buff Format
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BPBFormat),
       tooltip = GetString(FTC_Menu_BPBFormatDesc),
       choices = { GetString(FTC_BuffFormat1), GetString(FTC_BuffFormat2), GetString(FTC_BuffFormat3), GetString(FTC_BuffFormat4), GetString(FTC_BuffFormat5), GetString(FTC_BuffFormat6), GetString(FTC_BuffFormat0) },
       getFunc = function() return FTC.Menu:GetBuffFormat(FTC.Vars.PlayerBuffFormat) end,
       setFunc = function(value) FTC.Menu:UpdateBuffFormat('PlayerBuffFormat', value) end,
       default = FTC.Menu:GetBuffFormat(FTC.Defaults.PlayerBuffFormat),
-    },
+    }
 
     -- Player Debuff Format
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BPDFormat),
       tooltip = GetString(FTC_Menu_BPDFormatDesc),
       choices = { GetString(FTC_BuffFormat1), GetString(FTC_BuffFormat2), GetString(FTC_BuffFormat3), GetString(FTC_BuffFormat4), GetString(FTC_BuffFormat5), GetString(FTC_BuffFormat6), GetString(FTC_BuffFormat0) },
       getFunc = function() return FTC.Menu:GetBuffFormat(FTC.Vars.PlayerDebuffFormat) end,
       setFunc = function(value) FTC.Menu:UpdateBuffFormat('PlayerDebuffFormat', value) end,
       default = FTC.Menu:GetBuffFormat(FTC.Defaults.PlayerDebuffFormat),
-    },
+    }
 
     -- Long Buff Format
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BLBFormat),
       tooltip = GetString(FTC_Menu_BLBFormatDesc),
       choices = { GetString(FTC_BuffFormat1), GetString(FTC_BuffFormat2), GetString(FTC_BuffFormat3), GetString(FTC_BuffFormat4), GetString(FTC_BuffFormat5), GetString(FTC_BuffFormat6), GetString(FTC_BuffFormat0) },
       getFunc = function() return FTC.Menu:GetBuffFormat(FTC.Vars.LongBuffFormat) end,
       setFunc = function(value) FTC.Menu:UpdateBuffFormat('LongBuffFormat', value) end,
       default = FTC.Menu:GetBuffFormat(FTC.Defaults.LongBuffFormat),
-    },
+    }
 
     -- Target Buff Format
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BTBFormat),
       tooltip = GetString(FTC_Menu_BTBFormatDesc),
       choices = { GetString(FTC_BuffFormat1), GetString(FTC_BuffFormat2), GetString(FTC_BuffFormat3), GetString(FTC_BuffFormat4), GetString(FTC_BuffFormat5), GetString(FTC_BuffFormat6), GetString(FTC_BuffFormat0) },
       getFunc = function() return FTC.Menu:GetBuffFormat(FTC.Vars.TargetBuffFormat) end,
       setFunc = function(value) FTC.Menu:UpdateBuffFormat('TargetBuffFormat', value) end,
       default = FTC.Menu:GetBuffFormat(FTC.Defaults.TargetBuffFormat),
-    },
+    }
 
     -- Target Debuff Format
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BTDFormat),
       tooltip = GetString(FTC_Menu_BTDFormatDesc),
       choices = { GetString(FTC_BuffFormat1), GetString(FTC_BuffFormat2), GetString(FTC_BuffFormat3), GetString(FTC_BuffFormat4), GetString(FTC_BuffFormat5), GetString(FTC_BuffFormat6), GetString(FTC_BuffFormat0) },
       getFunc = function() return FTC.Menu:GetBuffFormat(FTC.Vars.TargetDebuffFormat) end,
       setFunc = function(value) FTC.Menu:UpdateBuffFormat('TargetDebuffFormat', value) end,
       default = FTC.Menu:GetBuffFormat(FTC.Defaults.TargetDebuffFormat),
-    },
+    }
 
     -- Primary Buffs Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BFont1),
       tooltip = GetString(FTC_Menu_BFont1Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.BuffsFont1) end,
       setFunc = function(value) FTC.Menu:UpdateBuffs("BuffsFont1", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.BuffsFont1,
-    },
+    }
 
     -- Secondary Buffs Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_BFont2),
       tooltip = GetString(FTC_Menu_BFont2Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.BuffsFont2) end,
       setFunc = function(value) FTC.Menu:UpdateBuffs("BuffsFont2", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.BuffsFont2,
-    },
+    }
 
     -- Frame Font Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_BFontS),
       tooltip = GetString(FTC_Menu_BFontSDesc),
       min = 12,
@@ -700,73 +768,74 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.BuffsFontSize end,
       setFunc = function(value) FTC.Menu:UpdateBuffs("BuffsFontSize", value) end,
       default = FTC.Defaults.BuffsFontSize
-    },
+    }
 
     -- Reset Buffs
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "button",
       name = GetString(FTC_Menu_BReset),
       tooltip = GetString(FTC_Menu_BResetDesc),
       func = function() FTC.Menu:Reset("Buffs") end,
-    },
-  }
-  if FTC.Vars.EnableBuffs then
-    for i = 1, #Buffs do table.insert(FTC.Menu.options, Buffs[i]) end
+    }
   end
 
 
   --[[----------------------------------------------------------
       COMBAT LOG
     ]]----------------------------------------------------------
-  local Log = {
+  if FTC.Vars.EnableLog then
 
     -- Buff Tracking Header
-    { type = "header",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "header",
       name = GetString(FTC_Menu_LHeader),
       width = "full"
-    },
+    }
 
     -- Alternate Log with Chat
-    { type = "checkbox",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "checkbox",
       name = GetString(FTC_Menu_LAltChat),
       tooltip = GetString(FTC_Menu_LAltChatDesc),
       getFunc = function() return FTC.Vars.AlternateChat end,
       setFunc = function(value) FTC.Menu:UpdateLog('AlternateChat', value) end,
       default = FTC.Defaults.AlternateChat,
-    },
+    }
 
     -- Hide healing?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_LHideHeal),
       tooltip = GetString(FTC_Menu_LHideHealDesc),
       getFunc = function() return FTC.Vars.LogHideHeal end,
       setFunc = function(value) FTC.Menu:Update('LogHideHeal', value) end,
       default = FTC.Defaults.LogHideHeal,
-    },
+    }
 
     -- Combat only healing?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_LCOH),
       tooltip = GetString(FTC_Menu_LCOHDesc),
       getFunc = function() return FTC.Vars.LogCOH end,
       setFunc = function(value) FTC.Menu:Update('LogCOH', value) end,
       default = FTC.Defaults.LogCOH,
-    },
+    }
 
     -- Combat Log Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_LFont),
       tooltip = GetString(FTC_Menu_LFontDesc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.LogFont) end,
       setFunc = function(value) FTC.Menu:UpdateLog("LogFont", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.LogFont,
-    },
+    }
 
     -- Combat Log Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_LFontS),
       tooltip = GetString(FTC_Menu_LFontSDesc),
       min = 12,
@@ -775,10 +844,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.LogFontSize end,
       setFunc = function(value) FTC.Menu:UpdateLog("LogFontSize", value) end,
       default = FTC.Defaults.LogFontSize
-    },
+    }
 
     -- Combat Log Opacity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_LOpacity),
       tooltip = GetString(FTC_Menu_LOpacityDesc),
       min = 0,
@@ -787,95 +857,92 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.LogOpacity end,
       setFunc = function(value) FTC.Menu:UpdateLog("LogOpacity", value) end,
       default = FTC.Defaults.LogOpacity
-    },
+    }
 
     -- Reset Log
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "button",
       name = GetString(FTC_Menu_LReset),
       tooltip = GetString(FTC_Menu_LResetDesc),
       func = function() FTC.Menu:Reset("Log") end,
-    },
-  }
-  if FTC.Vars.EnableLog then
-    for i = 1, #Log do table.insert(FTC.Menu.options, Log[i]) end
+    }
   end
 
 
   --[[----------------------------------------------------------
       SCROLLING COMBAT TEXT
     ]]----------------------------------------------------------
-  local SCT = {
-
-    -- SCT Header
-    {
+  -- SCT Header
+  if FTC.Vars.EnableSCT then
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "header",
       name = GetString(FTC_Menu_SHeader),
       width = "full",
-    },
+    }
 
     -- Display Ability Icons?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SIcons),
       tooltip = GetString(FTC_Menu_SIconsDesc),
       getFunc = function() return FTC.Vars.SCTIcons end,
       setFunc = function(value) FTC.Menu:Update('SCTIcons', value) end,
       default = FTC.Defaults.SCTIcons,
-    },
+    }
 
     -- Display Ability Names?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SNames),
       tooltip = GetString(FTC_Menu_SNamesDesc),
       getFunc = function() return FTC.Vars.SCTNames end,
       setFunc = function(value) FTC.Menu:Update('SCTNames', value) end,
       default = FTC.Defaults.SCTNames,
-    },
+    }
 
     -- Round Values?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SRound),
       tooltip = GetString(FTC_Menu_SRoundDesc),
       getFunc = function() return FTC.Vars.SCTRound end,
       setFunc = function(value) FTC.Menu:Update('SCTRound', value) end,
       default = FTC.Defaults.SCTRound,
-    },
+    }
 
     -- Display Alerts?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SAlerts),
       tooltip = GetString(FTC_Menu_SAlertsDesc),
       getFunc = function() return FTC.Vars.SCTAlerts end,
       setFunc = function(value) FTC.Menu:Update('SCTAlerts', value) end,
       default = FTC.Defaults.SCTAlerts,
-    },
+    }
 
     -- Hide healing?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SHideHeal),
       tooltip = GetString(FTC_Menu_SHideHealDesc),
       getFunc = function() return FTC.Vars.SCTHideHeal end,
       setFunc = function(value) FTC.Menu:Update('SCTHideHeal', value) end,
       default = FTC.Defaults.SCTHideHeal,
-    },
+    }
 
     -- Combat only healing?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_SCOH),
       tooltip = GetString(FTC_Menu_SCOHDesc),
       getFunc = function() return FTC.Vars.SCTCOH end,
       setFunc = function(value) FTC.Menu:Update('SCTCOH', value) end,
       default = FTC.Defaults.SCTCOH,
-    },
+    }
 
     -- SCT Scroll Speed
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_SSpeed),
       tooltip = GetString(FTC_Menu_SSpeedDesc),
       min = 0,
@@ -884,10 +951,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.SCTSpeed end,
       setFunc = function(value) FTC.Menu:Update("SCTSpeed", value) end,
       default = FTC.Defaults.SCTSpeed
-    },
+    }
 
     -- SCT Arc Intensity
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_SArc),
       tooltip = GetString(FTC_Menu_SArcDesc),
       min = -10,
@@ -896,50 +964,55 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.SCTArc end,
       setFunc = function(value) FTC.Menu:Update("SCTArc", value) end,
       default = FTC.Defaults.SCTArc
-    },
+    }
 
     -- Outgoing SCT Direction
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_SScrollOut),
       tooltip = GetString(FTC_Menu_SScrollOutDesc),
       choices = { "Up", "Down" },
       getFunc = function() return FTC.Vars.SCTOutScroll end,
       setFunc = function(value) FTC.Menu:Update("SCTOutScroll", value) end,
       default = FTC.Defaults.SCTOutScroll,
-    },
+    }
 
     -- Incoming SCT Direction
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_SScrollIn),
       tooltip = GetString(FTC_Menu_SScrollInDesc),
       choices = { "Up", "Down" },
       getFunc = function() return FTC.Vars.SCTInScroll end,
       setFunc = function(value) FTC.Menu:Update("SCTInScroll", value) end,
       default = FTC.Defaults.SCTInScroll,
-    },
+    }
 
     -- Primary SCT Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_SFont1),
       tooltip = GetString(FTC_Menu_SFont1Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.SCTFont1) end,
       setFunc = function(value) FTC.Menu:Update("SCTFont1", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.SCTFont1,
-    },
+    }
 
     -- Secondary SCT Font
-    { type = "dropdown",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "dropdown",
       name = GetString(FTC_Menu_SFont2),
       tooltip = GetString(FTC_Menu_SFont2Desc),
       choices = { "Metamorphous", "ESO Standard", "ESO Bold", "Prose Antique", "Handwritten", "Trajan Pro", "Futura Standard", "Futura Bold" },
       getFunc = function() return FTC.UI:TranslateFont(FTC.Vars.SCTFont2) end,
       setFunc = function(value) FTC.Menu:Update("SCTFont2", FTC.UI:TranslateFont(value)) end,
       default = FTC.Defaults.SCTFont2,
-    },
+    }
 
     -- SCT Font Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_SFontS),
       tooltip = GetString(FTC_Menu_SFontSDesc),
       min = 12,
@@ -948,10 +1021,11 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.SCTFontSize end,
       setFunc = function(value) FTC.Menu:Update("SCTFontSize", value) end,
       default = FTC.Defaults.SCTFontSize
-    },
+    }
 
     -- SCT Icon Size
-    { type = "slider",
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
+      type = "slider",
       name = GetString(FTC_Menu_SIconS),
       tooltip = GetString(FTC_Menu_SIconSDesc),
       min = 24,
@@ -960,34 +1034,31 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.SCTIconSize end,
       setFunc = function(value) FTC.Menu:Update("SCTIconSize", value) end,
       default = FTC.Defaults.SCTIconSize
-    },
+    }
 
     -- Reset SCT
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "button",
       name = GetString(FTC_Menu_SCTReset),
       tooltip = GetString(FTC_Menu_SCTResetDesc),
       func = function() FTC.Menu:Reset("SCT") end,
-    },
-  }
-  if FTC.Vars.EnableSCT then
-    for i = 1, #SCT do table.insert(FTC.Menu.options, SCT[i]) end
+    }
   end
 
   --[[----------------------------------------------------------
       DAMAGE STATISTICS
     ]]----------------------------------------------------------
-  local Stats = {
+  if FTC.Vars.EnableStats then
 
     -- Statistics Header
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "header",
       name = GetString(FTC_Menu_THeader),
       width = "full",
-    },
+    }
 
     -- Damage Tracker Timeout
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "slider",
       name = GetString(FTC_Menu_TTimeout),
       tooltip = GetString(FTC_Menu_TTimeoutDesc),
@@ -997,37 +1068,34 @@ function FTC.Menu:Controls()
       getFunc = function() return FTC.Vars.DamageTimeout end,
       setFunc = function(value) FTC.Menu:Update("DamageTimeout", value) end,
       default = FTC.Defaults.DamageTimeout,
-    },
+    }
 
     -- Reset Healing?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_TRHeal),
       tooltip = GetString(FTC_Menu_TRHealDesc),
       getFunc = function() return FTC.Vars.StatTriggerHeals end,
       setFunc = function(value) FTC.Menu:Update('StatTriggerHeals', value) end,
       default = FTC.Defaults.StatTriggerHeals,
-    },
+    }
 
     -- Share DPS with Group?
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "checkbox",
       name = GetString(FTC_Menu_TShare),
       tooltip = GetString(FTC_Menu_TShareDesc),
       getFunc = function() return FTC.Vars.StatsShareDPS end,
       setFunc = function(value) FTC.Menu:Update('StatsShareDPS', value) end,
       default = FTC.Defaults.StatsShareDPS,
-    },
+    }
 
     -- Reset Stats
-    {
+    FTC.Menu.options[#FTC.Menu.options + 1] = {
       type = "button",
       name = GetString(FTC_Menu_TReset),
       tooltip = GetString(FTC_Menu_TResetDesc),
       func = function() FTC.Menu:Reset("Stats") end,
-    },
-  }
-  if FTC.Vars.EnableStats then
-    for i = 1, #Stats do table.insert(FTC.Menu.options, Stats[i]) end
+    }
   end
 end


### PR DESCRIPTION
- Updated IsCritter to function as previously intended
- Added LAM menu toggle to hide or show critters in Target Frame
- Added LAM menu to choose color of Companion health bar
- Possible fix for #11 when unit frame info is not present
- Removed remaining texture strings using the class name from FTC.Frames:Controls() during Initialize to address issue #12 
- Updated SafetyCheck()